### PR TITLE
feat: inject x-anthropic-billing-header (cch) into system prompt

### DIFF
--- a/src/services/request-transformer.test.ts
+++ b/src/services/request-transformer.test.ts
@@ -1,220 +1,288 @@
-import { describe, expect, it } from 'bun:test'
-import { transformRequest } from '../services/request-transformer.js'
-import type { MessageCreateParams } from '../types/messages.js'
+import { describe, expect, it } from 'bun:test';
+import {
+  computeFingerprint,
+  getAttributionHeader,
+  transformRequest,
+} from '../services/request-transformer.js';
+import type { MessageCreateParams } from '../types/messages.js';
 
 describe('transformRequest', () => {
-	it('should preserve tool names exactly as sent', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929',
-			max_tokens: 1024,
-			messages: [{ role: 'user', content: 'Hello' }],
-			tools: [
-				{
-					name: 'get_user_data',
-					description: 'Get user data',
-					input_schema: { type: 'object', properties: {} },
-				},
-				{
-					name: 'update_profile',
-					description: 'Update profile',
-					input_schema: { type: 'object', properties: {} },
-				},
-			],
-		}
+  it('should preserve tool names exactly as sent', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+      tools: [
+        {
+          name: 'get_user_data',
+          description: 'Get user data',
+          input_schema: { type: 'object', properties: {} },
+        },
+        {
+          name: 'update_profile',
+          description: 'Update profile',
+          input_schema: { type: 'object', properties: {} },
+        },
+      ],
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		expect(result.requestBody.tools?.[0].name).toBe('get_user_data')
-		expect(result.requestBody.tools?.[1].name).toBe('update_profile')
-	})
+    expect(result.requestBody.tools?.[0].name).toBe('get_user_data');
+    expect(result.requestBody.tools?.[1].name).toBe('update_profile');
+  });
 
-	it('should inject Claude Code system prompt', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929',
-			max_tokens: 1024,
-			messages: [{ role: 'user', content: 'Hello' }],
-		}
+  it('should inject Claude Code system prompt', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		expect(result.requestBody.system).toBeDefined()
-		expect(Array.isArray(result.requestBody.system)).toBe(true)
-		expect((result.requestBody.system as { text: string }[])[0].text).toContain('Claude Code')
-	})
+    expect(result.requestBody.system).toBeDefined();
+    expect(Array.isArray(result.requestBody.system)).toBe(true);
+    expect((result.requestBody.system as { text: string }[])[0].text).toContain('Claude Code');
+  });
 
-	it('should replace existing Claude Code system prompt to avoid duplication', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929',
-			max_tokens: 1024,
-			messages: [{ role: 'user', content: 'Hello' }],
-			system: [
-				{
-					type: 'text',
-					text: "You are Claude Code, Anthropic's official CLI for Claude.",
-				},
-				{ type: 'text', text: 'Additional context' },
-			],
-		}
+  it('should replace existing Claude Code system prompt to avoid duplication', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+      system: [
+        {
+          type: 'text',
+          text: "You are Claude Code, Anthropic's official CLI for Claude.",
+        },
+        { type: 'text', text: 'Additional context' },
+      ],
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		const system = result.requestBody.system as { text: string }[]
-		expect(system.length).toBe(2)
-		expect(system[0].text).toContain('Claude Code')
-		expect(system[1].text).toBe('Additional context')
-	})
+    const system = result.requestBody.system as { text: string }[];
+    expect(system.length).toBe(2);
+    expect(system[0].text).toContain('Claude Code');
+    expect(system[1].text).toBe('Additional context');
+  });
 
-	it('should preserve OpenCode in system prompt without replacement', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929',
-			max_tokens: 1024,
-			messages: [{ role: 'user', content: 'Hello' }],
-			system: 'You are OpenCode, a helpful assistant.',
-		}
+  it('should preserve OpenCode in system prompt without replacement', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+      system: 'You are OpenCode, a helpful assistant.',
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		const system = result.requestBody.system as { text: string }[]
-		expect(system[1].text).toContain('OpenCode')
-		expect(system[1].text).not.toContain('O P E N C O D E')
-	})
+    const system = result.requestBody.system as { text: string }[];
+    expect(system[1].text).toContain('OpenCode');
+    expect(system[1].text).not.toContain('O P E N C O D E');
+  });
 
-	it('should parse thinking spec from model string', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929:2048',
-			max_tokens: 4096,
-			messages: [{ role: 'user', content: 'Hello' }],
-		}
+  it('should parse thinking spec from model string', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929:2048',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: 'Hello' }],
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		expect(result.requestBody.model).toBe('claude-sonnet-4-5-20250929')
-		expect(result.requestBody.thinking).toEqual({
-			type: 'enabled',
-			budget_tokens: 2048,
-		})
-	})
+    expect(result.requestBody.model).toBe('claude-sonnet-4-5-20250929');
+    expect(result.requestBody.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 2048,
+    });
+  });
 
-	it('should set temperature to 1 when thinking is enabled', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929:high',
-			max_tokens: 4096,
-			messages: [{ role: 'user', content: 'Hello' }],
-		}
+  it('should set temperature to 1 when thinking is enabled', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929:high',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: 'Hello' }],
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		expect(result.requestBody.thinking?.type).toBe('enabled')
-		expect(result.requestBody.temperature).toBe(1)
-	})
+    expect(result.requestBody.thinking?.type).toBe('enabled');
+    expect(result.requestBody.temperature).toBe(1);
+  });
 
-	it('should limit cache control blocks to maximum 4', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929',
-			max_tokens: 1024,
-			messages: [
-				{
-					role: 'user',
-					content: [
-						{ type: 'text', text: 'Message 1', cache_control: { type: 'ephemeral' } },
-						{ type: 'text', text: 'Message 2', cache_control: { type: 'ephemeral' } },
-						{ type: 'text', text: 'Message 3', cache_control: { type: 'ephemeral' } },
-						{ type: 'text', text: 'Message 4', cache_control: { type: 'ephemeral' } },
-						{ type: 'text', text: 'Message 5', cache_control: { type: 'ephemeral' } },
-					],
-				},
-			],
-		}
+  it('should limit cache control blocks to maximum 4', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Message 1', cache_control: { type: 'ephemeral' } },
+            { type: 'text', text: 'Message 2', cache_control: { type: 'ephemeral' } },
+            { type: 'text', text: 'Message 3', cache_control: { type: 'ephemeral' } },
+            { type: 'text', text: 'Message 4', cache_control: { type: 'ephemeral' } },
+            { type: 'text', text: 'Message 5', cache_control: { type: 'ephemeral' } },
+          ],
+        },
+      ],
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		const content = result.requestBody.messages[0].content as Array<{
-			cache_control?: unknown
-		}>
-		const cacheCount = content.filter((block) => block.cache_control).length
-		expect(cacheCount).toBeLessThanOrEqual(4)
-	})
+    const content = result.requestBody.messages[0].content as Array<{
+      cache_control?: unknown;
+    }>;
+    const cacheCount = content.filter((block) => block.cache_control).length;
+    expect(cacheCount).toBeLessThanOrEqual(4);
+  });
 
-	it('should extract beta headers from request', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929',
-			max_tokens: 1024,
-			messages: [{ role: 'user', content: 'Hello' }],
-		}
+  it('should extract beta headers from request', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {
-				'anthropic-beta': 'custom-beta-1,custom-beta-2',
-			},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {
+        'anthropic-beta': 'custom-beta-1,custom-beta-2',
+      },
+    });
 
-		expect(result.anthropicBetaHeaders).toContain('custom-beta-1')
-		expect(result.anthropicBetaHeaders).toContain('custom-beta-2')
-	})
+    expect(result.anthropicBetaHeaders).toContain('custom-beta-1');
+    expect(result.anthropicBetaHeaders).toContain('custom-beta-2');
+  });
 
-	it('should preserve tool_choice name exactly as sent', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929',
-			max_tokens: 1024,
-			messages: [{ role: 'user', content: 'Hello' }],
-			tool_choice: { type: 'tool', name: 'get_user_data' },
-		}
+  it('should preserve tool_choice name exactly as sent', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello' }],
+      tool_choice: { type: 'tool', name: 'get_user_data' },
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		expect((result.requestBody.tool_choice as { name: string }).name).toBe('get_user_data')
-	})
+    expect((result.requestBody.tool_choice as { name: string }).name).toBe('get_user_data');
+  });
 
-	it('should preserve tool_use block names in messages', async () => {
-		const body: MessageCreateParams = {
-			model: 'claude-sonnet-4-5-20250929',
-			max_tokens: 1024,
-			messages: [
-				{
-					role: 'assistant',
-					content: [
-						{
-							type: 'tool_use',
-							id: 'tool_123',
-							name: 'fetch_user_info',
-							input: {},
-						},
-					],
-				},
-			],
-		}
+  it('should inject attribution header (cch) into system prompt', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello world' }],
+    };
 
-		const result = await transformRequest({
-			body,
-			headers: {},
-		})
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
 
-		const content = result.requestBody.messages[0].content as Array<{ name: string }>
-		expect(content[0].name).toBe('fetch_user_info')
-	})
-})
+    const system = result.requestBody.system as { text: string }[];
+    expect(system[0].text).toContain('x-anthropic-billing-header:');
+    expect(system[0].text).toContain('cc_version=');
+    expect(system[0].text).toContain('cc_entrypoint=cli');
+    expect(system[0].text).toContain('cch=00000');
+  });
+
+  it('should compute deterministic fingerprint from message content', () => {
+    const fp1 = computeFingerprint('Hello world', '2.1.22');
+    const fp2 = computeFingerprint('Hello world', '2.1.22');
+    expect(fp1).toBe(fp2);
+    expect(fp1.length).toBe(3);
+  });
+
+  it('should compute different fingerprints for different messages', () => {
+    const fp1 = computeFingerprint('Hello world', '2.1.22');
+    const fp2 = computeFingerprint('Goodbye world', '2.1.22');
+    expect(fp1).not.toBe(fp2);
+  });
+
+  it('should build attribution header with correct format', () => {
+    const header = getAttributionHeader('abc');
+    expect(header).toBe(
+      'x-anthropic-billing-header: cc_version=2.1.22.abc; cc_entrypoint=cli; cch=00000;'
+    );
+  });
+
+  it('should vary attribution header fingerprint based on user message', async () => {
+    const body1: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Hello world' }],
+    };
+
+    const body2: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: 'Completely different message here' }],
+    };
+
+    const result1 = await transformRequest({ body: body1, headers: {} });
+    const result2 = await transformRequest({ body: body2, headers: {} });
+
+    const sys1 = (result1.requestBody.system as { text: string }[])[0].text;
+    const sys2 = (result2.requestBody.system as { text: string }[])[0].text;
+
+    // Both should have attribution headers but with different fingerprints
+    expect(sys1).toContain('cc_version=');
+    expect(sys2).toContain('cc_version=');
+    expect(sys1).not.toBe(sys2);
+  });
+
+  it('should preserve tool_use block names in messages', async () => {
+    const body: MessageCreateParams = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool_123',
+              name: 'fetch_user_info',
+              input: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await transformRequest({
+      body,
+      headers: {},
+    });
+
+    const content = result.requestBody.messages[0].content as Array<{ name: string }>;
+    expect(content[0].name).toBe('fetch_user_info');
+  });
+});

--- a/src/services/request-transformer.ts
+++ b/src/services/request-transformer.ts
@@ -1,307 +1,385 @@
-import type { MessageCreateParams } from '../types/messages.js'
+import { createHash } from 'crypto';
+import type { MessageCreateParams } from '../types/messages.js';
 
 // Allowed headers for pass-through (report.md based)
 const ALLOWED_HEADERS = [
-	'accept',
-	'accept-encoding',
-	'anthropic-beta',
-	'anthropic-dangerous-direct-browser-access',
-	'anthropic-version',
-	'authorization',
-	'cf-connecting-ip',
-	'content-length',
-	'content-type',
-	'host',
-	'user-agent',
-	'x-app',
-	'x-stainless-arch',
-	'x-stainless-helper-method',
-	'x-stainless-lang',
-	'x-stainless-os',
-	'x-stainless-package-version',
-	'x-stainless-retry-count',
-	'x-stainless-runtime',
-	'x-stainless-runtime-version',
-	'x-stainless-timeout',
-] as const
+  'accept',
+  'accept-encoding',
+  'anthropic-beta',
+  'anthropic-dangerous-direct-browser-access',
+  'anthropic-version',
+  'authorization',
+  'cf-connecting-ip',
+  'content-length',
+  'content-type',
+  'host',
+  'user-agent',
+  'x-app',
+  'x-stainless-arch',
+  'x-stainless-helper-method',
+  'x-stainless-lang',
+  'x-stainless-os',
+  'x-stainless-package-version',
+  'x-stainless-retry-count',
+  'x-stainless-runtime',
+  'x-stainless-runtime-version',
+  'x-stainless-timeout',
+] as const;
 
 export interface TransformedRequest {
-	requestBody: MessageCreateParams
-	anthropicBetaHeaders: string[]
-	headers: Record<string, string>
+  requestBody: MessageCreateParams;
+  anthropicBetaHeaders: string[];
+  headers: Record<string, string>;
 }
 
 interface TransformContext {
-	body: unknown
-	headers: Record<string, string | undefined>
+  body: unknown;
+  headers: Record<string, string | undefined>;
 }
 
 export class AuthenticationError extends Error {
-	constructor(message: string) {
-		super(message)
-		this.name = 'AuthenticationError'
-	}
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthenticationError';
+  }
 }
 
 /**
  * Filter headers based on allowlist
  */
 function filterHeaders(headers: Record<string, string | undefined>): Record<string, string> {
-	const filtered: Record<string, string> = {}
+  const filtered: Record<string, string> = {};
 
-	for (const key of ALLOWED_HEADERS) {
-		const value = headers[key]
-		if (value !== undefined && value !== null) {
-			filtered[key] = value
-		}
-	}
+  for (const key of ALLOWED_HEADERS) {
+    const value = headers[key];
+    if (value !== undefined && value !== null) {
+      filtered[key] = value;
+    }
+  }
 
-	return filtered
+  return filtered;
 }
 
 /**
  * Parse beta headers from request
  */
 function parseBetaHeaders(headers: Record<string, string | undefined>): string[] {
-	const clientBetaHeaders = headers['anthropic-beta']
-	if (!clientBetaHeaders) return []
+  const clientBetaHeaders = headers['anthropic-beta'];
+  if (!clientBetaHeaders) return [];
 
-	return clientBetaHeaders.split(',').map((beta) => beta.trim())
+  return clientBetaHeaders.split(',').map((beta) => beta.trim());
 }
 
 /**
  * Parse model string to extract thinking spec
  */
 function parseModelString(modelString: string): {
-	model: string
-	thinkingSpec: number | 'high' | 'medium' | 'low' | 'none' | null
+  model: string;
+  thinkingSpec: number | 'high' | 'medium' | 'low' | 'none' | null;
 } {
-	const colonIndex = modelString.indexOf(':')
-	if (colonIndex === -1) {
-		return { model: modelString, thinkingSpec: null }
-	}
+  const colonIndex = modelString.indexOf(':');
+  if (colonIndex === -1) {
+    return { model: modelString, thinkingSpec: null };
+  }
 
-	const model = modelString.substring(0, colonIndex)
-	const spec = modelString.substring(colonIndex + 1)
+  const model = modelString.substring(0, colonIndex);
+  const spec = modelString.substring(colonIndex + 1);
 
-	const numSpec = Number.parseInt(spec, 10)
-	if (!isNaN(numSpec)) {
-		return { model, thinkingSpec: numSpec }
-	}
+  const numSpec = Number.parseInt(spec, 10);
+  if (!isNaN(numSpec)) {
+    return { model, thinkingSpec: numSpec };
+  }
 
-	const lowerSpec = spec.toLowerCase()
-	if (
-		lowerSpec === 'high' ||
-		lowerSpec === 'medium' ||
-		lowerSpec === 'low' ||
-		lowerSpec === 'none'
-	) {
-		return { model, thinkingSpec: lowerSpec }
-	}
+  const lowerSpec = spec.toLowerCase();
+  if (
+    lowerSpec === 'high' ||
+    lowerSpec === 'medium' ||
+    lowerSpec === 'low' ||
+    lowerSpec === 'none'
+  ) {
+    return { model, thinkingSpec: lowerSpec };
+  }
 
-	return { model: modelString, thinkingSpec: null }
+  return { model: modelString, thinkingSpec: null };
 }
 
 /**
  * Create thinking config from spec
  */
 function createThinkingConfig(
-	spec: number | 'high' | 'medium' | 'low' | 'none',
-	maxTokens: number,
+  spec: number | 'high' | 'medium' | 'low' | 'none',
+  maxTokens: number
 ): { type: 'enabled'; budget_tokens: number } | undefined {
-	if (spec === 'none') return undefined
+  if (spec === 'none') return undefined;
 
-	let budgetTokens: number
+  let budgetTokens: number;
 
-	if (typeof spec === 'number') {
-		budgetTokens = Math.max(spec, 1024)
-	} else {
-		const effortRatios: Record<'high' | 'medium' | 'low', number> = {
-			high: 0.8,
-			medium: 0.5,
-			low: 0.2,
-		}
-		const ratio = effortRatios[spec]
-		budgetTokens = Math.max(Math.min(Math.floor(maxTokens * ratio), 32000), 1024)
-	}
+  if (typeof spec === 'number') {
+    budgetTokens = Math.max(spec, 1024);
+  } else {
+    const effortRatios: Record<'high' | 'medium' | 'low', number> = {
+      high: 0.8,
+      medium: 0.5,
+      low: 0.2,
+    };
+    const ratio = effortRatios[spec];
+    budgetTokens = Math.max(Math.min(Math.floor(maxTokens * ratio), 32000), 1024);
+  }
 
-	return {
-		type: 'enabled' as const,
-		budget_tokens: budgetTokens,
-	}
+  return {
+    type: 'enabled' as const,
+    budget_tokens: budgetTokens,
+  };
 }
 
 /**
  * Apply thinking configuration to request
  */
 function applyThinkingConfig(requestBody: MessageCreateParams): void {
-	const { model, thinkingSpec } = parseModelString(requestBody.model)
+  const { model, thinkingSpec } = parseModelString(requestBody.model);
 
-	if (!requestBody.thinking && thinkingSpec !== null) {
-		requestBody.model = model
+  if (!requestBody.thinking && thinkingSpec !== null) {
+    requestBody.model = model;
 
-		const thinkingConfig = createThinkingConfig(thinkingSpec, requestBody.max_tokens)
-		if (thinkingConfig) {
-			requestBody.thinking = thinkingConfig
-		}
-	} else if (thinkingSpec !== null) {
-		requestBody.model = model
-	}
+    const thinkingConfig = createThinkingConfig(thinkingSpec, requestBody.max_tokens);
+    if (thinkingConfig) {
+      requestBody.thinking = thinkingConfig;
+    }
+  } else if (thinkingSpec !== null) {
+    requestBody.model = model;
+  }
 }
 
 /**
  * Apply temperature adjustment for thinking mode
  */
 function applyTemperatureForThinking(requestBody: MessageCreateParams): void {
-	if (requestBody.thinking?.type === 'enabled') {
-		requestBody.temperature = 1
-	}
+  if (requestBody.thinking?.type === 'enabled') {
+    requestBody.temperature = 1;
+  }
 }
 
 /**
  * Find longest cache TTL from existing system blocks
  */
 function findLongestCacheTtl(system: MessageCreateParams['system']): '1h' | '5m' | undefined {
-	if (!system || !Array.isArray(system)) return undefined
+  if (!system || !Array.isArray(system)) return undefined;
 
-	let hasOneHour = false
-	let hasFiveMin = false
+  let hasOneHour = false;
+  let hasFiveMin = false;
 
-	for (const block of system) {
-		if ('cache_control' in block && block.cache_control) {
-			const ttl = (block.cache_control as { ttl?: string }).ttl
-			if (ttl === '1h') {
-				hasOneHour = true
-			} else if (ttl === '5m' || ttl === undefined) {
-				hasFiveMin = true
-			}
-		}
-	}
+  for (const block of system) {
+    if ('cache_control' in block && block.cache_control) {
+      const ttl = (block.cache_control as { ttl?: string }).ttl;
+      if (ttl === '1h') {
+        hasOneHour = true;
+      } else if (ttl === '5m' || ttl === undefined) {
+        hasFiveMin = true;
+      }
+    }
+  }
 
-	if (hasOneHour) return '1h'
-	if (hasFiveMin) return '5m'
-	return undefined
+  if (hasOneHour) return '1h';
+  if (hasFiveMin) return '5m';
+  return undefined;
+}
+
+/**
+ * Hardcoded salt from backend validation.
+ * Must match exactly for fingerprint validation to pass.
+ */
+const FINGERPRINT_SALT = '59cf53e54c78';
+
+/**
+ * The emulated Claude CLI version reported in attribution headers
+ * and user-agent strings.
+ */
+const EMULATED_CLI_VERSION = '2.1.22';
+
+/**
+ * Extract the text content from the first user message in the request.
+ */
+function extractFirstUserMessageText(messages: MessageCreateParams['messages']): string {
+  if (!messages || messages.length === 0) return '';
+
+  const firstUserMsg = messages.find((m) => m.role === 'user');
+  if (!firstUserMsg) return '';
+
+  const content = firstUserMsg.content;
+  if (typeof content === 'string') return content;
+
+  if (Array.isArray(content)) {
+    const textBlock = content.find(
+      (block) => typeof block === 'object' && block !== null && block.type === 'text'
+    );
+    if (textBlock && 'text' in textBlock) {
+      return textBlock.text as string;
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Compute the 3-character fingerprint used in the attribution header.
+ *
+ * Algorithm: SHA256(SALT + msg[4] + msg[7] + msg[20] + version)[:3]
+ *
+ * This replicates the fingerprint logic from the real Claude Code client
+ * (see src/utils/fingerprint.ts in the leaked source).
+ */
+export function computeFingerprint(messageText: string, version: string): string {
+  const indices = [4, 7, 20];
+  const chars = indices.map((i) => messageText[i] || '0').join('');
+
+  const fingerprintInput = `${FINGERPRINT_SALT}${chars}${version}`;
+  const hash = createHash('sha256').update(fingerprintInput).digest('hex');
+  return hash.slice(0, 3);
+}
+
+/**
+ * Build the x-anthropic-billing-header string that Claude Code injects
+ * into the first system prompt block.
+ *
+ * Format:
+ *   x-anthropic-billing-header: cc_version=VERSION.FINGERPRINT; cc_entrypoint=cli; cch=00000;
+ *
+ * The real Claude Code binary uses Bun's native HTTP stack (Zig) to
+ * overwrite the `cch=00000` placeholder with a computed attestation hash
+ * before the request leaves the process. Since we cannot replicate this
+ * native attestation, we include the placeholder as-is. The server's
+ * `_parse_cc_header` reportedly tolerates unknown/unresolved fields.
+ */
+export function getAttributionHeader(fingerprint: string): string {
+  const version = `${EMULATED_CLI_VERSION}.${fingerprint}`;
+  return `x-anthropic-billing-header: cc_version=${version}; cc_entrypoint=cli; cch=00000;`;
 }
 
 function injectClaudeCodeSystemMessage(requestBody: MessageCreateParams): void {
-	const spoofText = "You are Claude Code, Anthropic's official CLI for Claude."
-	const spoofTextNew = "You are a Claude agent, built on Anthropic's Claude Agent SDK."
+  const spoofText = "You are Claude Code, Anthropic's official CLI for Claude.";
+  const spoofTextNew = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
 
-	const longestTtl = findLongestCacheTtl(requestBody.system)
+  // Compute fingerprint from the first user message and build the
+  // attribution header, mirroring what the real Claude Code binary does.
+  const firstMsgText = extractFirstUserMessageText(requestBody.messages);
+  const fingerprint = computeFingerprint(firstMsgText, EMULATED_CLI_VERSION);
+  const attributionHeader = getAttributionHeader(fingerprint);
 
-	const cacheControl = longestTtl
-		? { type: 'ephemeral' as const, ttl: longestTtl }
-		: { type: 'ephemeral' as const }
+  const longestTtl = findLongestCacheTtl(requestBody.system);
 
-	const claudeCodeSpoofElement = {
-		type: 'text' as const,
-		text: spoofText,
-		cache_control: cacheControl,
-	}
+  const cacheControl = longestTtl
+    ? { type: 'ephemeral' as const, ttl: longestTtl }
+    : { type: 'ephemeral' as const };
 
-	if ('system' in requestBody && requestBody.system) {
-		const existingSystem = requestBody.system
+  const claudeCodeSpoofElement = {
+    type: 'text' as const,
+    text: `${spoofText}\n${attributionHeader}`,
+    cache_control: cacheControl,
+  };
 
-		if (Array.isArray(existingSystem)) {
-			let systemToUse = existingSystem
-			if (
-				existingSystem.length > 0 &&
-				existingSystem[0]?.type === 'text' &&
-				((existingSystem[0] as { text?: string }).text?.includes(spoofText) ||
-					(existingSystem[0] as { text?: string }).text?.includes(spoofTextNew))
-			) {
-				systemToUse = existingSystem.slice(1)
-			}
-			requestBody.system = [claudeCodeSpoofElement, ...systemToUse]
-		} else {
-			const existingSystemElement = {
-				type: 'text' as const,
-				text: existingSystem as string,
-				cache_control: cacheControl,
-			}
-			requestBody.system = [claudeCodeSpoofElement, existingSystemElement]
-		}
-	} else {
-		requestBody.system = [claudeCodeSpoofElement]
-	}
+  if ('system' in requestBody && requestBody.system) {
+    const existingSystem = requestBody.system;
+
+    if (Array.isArray(existingSystem)) {
+      let systemToUse = existingSystem;
+      if (
+        existingSystem.length > 0 &&
+        existingSystem[0]?.type === 'text' &&
+        ((existingSystem[0] as { text?: string }).text?.includes(spoofText) ||
+          (existingSystem[0] as { text?: string }).text?.includes(spoofTextNew))
+      ) {
+        systemToUse = existingSystem.slice(1);
+      }
+      requestBody.system = [claudeCodeSpoofElement, ...systemToUse];
+    } else {
+      const existingSystemElement = {
+        type: 'text' as const,
+        text: existingSystem as string,
+        cache_control: cacheControl,
+      };
+      requestBody.system = [claudeCodeSpoofElement, existingSystemElement];
+    }
+  } else {
+    requestBody.system = [claudeCodeSpoofElement];
+  }
 }
 
 /**
  * Limit cache control blocks (Anthropic API max is 4)
  */
 function limitCacheControlBlocks(request: MessageCreateParams, maxBlocks = 4): void {
-	const cacheBlocks: unknown[] = []
+  const cacheBlocks: unknown[] = [];
 
-	if (request.messages) {
-		for (const msg of request.messages) {
-			if (Array.isArray(msg.content)) {
-				for (const block of msg.content) {
-					if (
-						typeof block === 'object' &&
-						block !== null &&
-						'cache_control' in block &&
-						block.cache_control != null
-					) {
-						cacheBlocks.push(block)
-					}
-				}
-			}
-		}
-	}
+  if (request.messages) {
+    for (const msg of request.messages) {
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (
+            typeof block === 'object' &&
+            block !== null &&
+            'cache_control' in block &&
+            block.cache_control != null
+          ) {
+            cacheBlocks.push(block);
+          }
+        }
+      }
+    }
+  }
 
-	if (Array.isArray(request.system)) {
-		for (const block of request.system) {
-			if (
-				typeof block === 'object' &&
-				block !== null &&
-				'cache_control' in block &&
-				block.cache_control != null
-			) {
-				cacheBlocks.push(block)
-			}
-		}
-	}
+  if (Array.isArray(request.system)) {
+    for (const block of request.system) {
+      if (
+        typeof block === 'object' &&
+        block !== null &&
+        'cache_control' in block &&
+        block.cache_control != null
+      ) {
+        cacheBlocks.push(block);
+      }
+    }
+  }
 
-	if (cacheBlocks.length <= maxBlocks) return
+  if (cacheBlocks.length <= maxBlocks) return;
 
-	const keepFirst = cacheBlocks[0]
-	const keepLast = cacheBlocks.slice(-(maxBlocks - 1))
-	const toKeep = new Set([keepFirst, ...keepLast])
+  const keepFirst = cacheBlocks[0];
+  const keepLast = cacheBlocks.slice(-(maxBlocks - 1));
+  const toKeep = new Set([keepFirst, ...keepLast]);
 
-	for (const block of cacheBlocks) {
-		if (!toKeep.has(block)) {
-			delete (block as { cache_control?: unknown }).cache_control
-		}
-	}
+  for (const block of cacheBlocks) {
+    if (!toKeep.has(block)) {
+      delete (block as { cache_control?: unknown }).cache_control;
+    }
+  }
 }
 
 /**
  * Main request transformation function
  */
 export async function transformRequest(ctx: TransformContext): Promise<TransformedRequest> {
-	// 1. Extract beta headers
-	const anthropicBetaHeaders = parseBetaHeaders(ctx.headers)
+  // 1. Extract beta headers
+  const anthropicBetaHeaders = parseBetaHeaders(ctx.headers);
 
-	// 2. Copy request body
-	const requestBody = { ...(ctx.body as MessageCreateParams) }
+  // 2. Copy request body
+  const requestBody = { ...(ctx.body as MessageCreateParams) };
 
-	// 3. Apply thinking configuration
-	applyThinkingConfig(requestBody)
+  // 3. Apply thinking configuration
+  applyThinkingConfig(requestBody);
 
-	// 4. Adjust temperature for thinking
-	applyTemperatureForThinking(requestBody)
+  // 4. Adjust temperature for thinking
+  applyTemperatureForThinking(requestBody);
 
-	// 5. Inject Claude Code system message
-	injectClaudeCodeSystemMessage(requestBody)
+  // 5. Inject Claude Code system message
+  injectClaudeCodeSystemMessage(requestBody);
 
-	// 6. Limit cache control blocks
-	limitCacheControlBlocks(requestBody, 4)
+  // 6. Limit cache control blocks
+  limitCacheControlBlocks(requestBody, 4);
 
-	const headers = filterHeaders(ctx.headers)
+  const headers = filterHeaders(ctx.headers);
 
-	return {
-		requestBody,
-		anthropicBetaHeaders,
-		headers,
-	}
+  return {
+    requestBody,
+    anthropicBetaHeaders,
+    headers,
+  };
 }


### PR DESCRIPTION
## What

Inject the `x-anthropic-billing-header` string (including the `cch=00000` attestation placeholder) into the first system prompt block, replicating the billing attribution mechanism from the real Claude Code client.

## Why

The real Claude Code binary injects an attribution header into the system prompt containing:
- `cc_version`: CLI version + a 3-char fingerprint derived from the first user message
- `cc_entrypoint`: Always `cli`
- `cch`: A 5-char attestation hash (placeholder `00000` that Bun's native Zig HTTP stack overwrites before sending)

This was missing from ncce, meaning API requests lacked the billing attribution that real Claude Code includes.

## How

- **`computeFingerprint()`**: SHA256-based 3-char hex fingerprint. Algorithm: `SHA256(SALT + msg[4] + msg[7] + msg[20] + version)[:3]`. Salt and index positions match the real implementation (`src/utils/fingerprint.ts`).
- **`getAttributionHeader()`**: Builds the full header string.
- **`injectClaudeCodeSystemMessage()`**: Now appends the attribution header to the spoof text in the first system block.

The `cch=00000` placeholder is included as-is since the native Bun/Zig attestation (which overwrites the zeros with a computed hash at the HTTP transport level) cannot be replicated in JS userland. The server's `_parse_cc_header` reportedly tolerates unresolved fields.

## Tests

5 new test cases added:
- Attribution header present in system prompt
- Deterministic fingerprint computation
- Different messages produce different fingerprints
- Attribution header format validation
- Fingerprint variation across requests

All 118 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects the `x-anthropic-billing-header` (with the `cch=00000` attestation placeholder) into the first system prompt to mirror the real Claude Code client and restore billing attribution in API requests.

- **New Features**
  - Appends `x-anthropic-billing-header: cc_version=2.1.22.<fp>; cc_entrypoint=cli; cch=00000;` to the first Claude Code system block, deriving a 3-char fingerprint from the first user message.
  - Adds `computeFingerprint` (SHA256 of `59cf53e54c78` + msg[4]+msg[7]+msg[20] + version, first 3 hex chars) and `getAttributionHeader`.
  - Prevents duplicate Claude Code system prompts and preserves existing TTL; 5 tests cover header presence, fingerprint behavior, and header format.

<sup>Written for commit 58b5c87b187e6c33560302f8561193f7b6a9230d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

