### PR TITLE
feat: implement cch request signing (xxHash64 body integrity hash)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "hono": "^4.6.0",
+        "xxhash-wasm": "^1.1.0",
         "zod": "^3.23.0",
       },
       "devDependencies": {
@@ -57,6 +58,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "not-claude-code-emulator",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Hono-based OAuth server for Anthropic API with Claude Code-style OAuth integration",
   "license": "MIT",
   "type": "module",
@@ -39,10 +39,11 @@
   "dependencies": {
     "@hono/zod-openapi": "^0.18.0",
     "@scalar/hono-api-reference": "^0.5.0",
-    "hono": "^4.6.0",
-    "zod": "^3.23.0",
+    "chalk": "^5.3.0",
     "commander": "^12.0.0",
-    "chalk": "^5.3.0"
+    "hono": "^4.6.0",
+    "xxhash-wasm": "^1.1.0",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/services/cch.test.ts
+++ b/src/services/cch.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test';
+import { computeCch, hasCchPlaceholder, replaceCchPlaceholder } from './cch.js';
+
+describe('cch signing', () => {
+  it('should compute a 5-character hex hash', async () => {
+    const body = '{"system":[{"type":"text","text":"cch=00000"}],"messages":[]}';
+    const cch = await computeCch(body);
+    expect(cch).toMatch(/^[0-9a-f]{5}$/);
+  });
+
+  it('should be deterministic for the same input', async () => {
+    const body = '{"system":[{"type":"text","text":"cch=00000"}],"messages":[{"role":"user","content":"Hello"}]}';
+    const cch1 = await computeCch(body);
+    const cch2 = await computeCch(body);
+    expect(cch1).toBe(cch2);
+  });
+
+  it('should produce different hashes for different bodies', async () => {
+    const body1 = '{"system":[{"type":"text","text":"cch=00000"}],"messages":[{"role":"user","content":"Hello"}]}';
+    const body2 = '{"system":[{"type":"text","text":"cch=00000"}],"messages":[{"role":"user","content":"World"}]}';
+    const cch1 = await computeCch(body1);
+    const cch2 = await computeCch(body2);
+    expect(cch1).not.toBe(cch2);
+  });
+
+  it('should detect cch placeholder', () => {
+    expect(hasCchPlaceholder('some text cch=00000 more text')).toBe(true);
+    expect(hasCchPlaceholder('some text without placeholder')).toBe(false);
+  });
+
+  it('should replace cch placeholder', () => {
+    const body = '{"text":"cch=00000"}';
+    const result = replaceCchPlaceholder(body, 'a1b2c');
+    expect(result).toBe('{"text":"cch=a1b2c"}');
+    expect(result).not.toContain('cch=00000');
+  });
+
+  it('should not produce cch=00000 as output', async () => {
+    // Edge case: make sure the hash never coincidentally equals the placeholder
+    const bodies = [
+      '{"cch=00000":"test"}',
+      '{"system":"cch=00000","model":"claude-3"}',
+      '{"messages":[],"cch=00000":""}',
+    ];
+    for (const body of bodies) {
+      const cch = await computeCch(body);
+      // While theoretically possible, 00000 is extremely unlikely
+      // This test documents the behavior rather than being a hard guarantee
+      expect(cch).toMatch(/^[0-9a-f]{5}$/);
+    }
+  });
+});

--- a/src/services/cch.ts
+++ b/src/services/cch.ts
@@ -1,0 +1,52 @@
+/**
+ * CCH (Claude Code Hash) request signing module.
+ *
+ * Implements the xxHash64-based body integrity hash that the real Claude Code
+ * binary computes in Bun's native HTTP stack (Zig). The algorithm was
+ * reverse-engineered and documented at:
+ * https://a10k.co/b/reverse-engineering-claude-code-cch.html
+ *
+ * Algorithm:
+ * 1. Build the complete request body with `cch=00000` as placeholder
+ * 2. Compute `xxHash64(body_bytes, seed) & 0xFFFFF`
+ * 3. Format as zero-padded 5-character lowercase hex
+ * 4. Replace `cch=00000` with the computed value in the body
+ */
+import xxhash from 'xxhash-wasm';
+
+const CCH_SEED = 0x6e52736ac806831en;
+const CCH_PLACEHOLDER = 'cch=00000';
+const CCH_MASK = 0xfffffn;
+
+let hasherPromise: ReturnType<typeof xxhash> | null = null;
+
+function getHasher() {
+  if (!hasherPromise) {
+    hasherPromise = xxhash();
+  }
+  return hasherPromise;
+}
+
+/**
+ * Compute the 5-character cch hash from the serialized request body.
+ * The body must contain the `cch=00000` placeholder at this point.
+ */
+export async function computeCch(body: string): Promise<string> {
+  const hasher = await getHasher();
+  const hash = hasher.h64Raw(new TextEncoder().encode(body), CCH_SEED);
+  return (hash & CCH_MASK).toString(16).padStart(5, '0');
+}
+
+/**
+ * Replace the `cch=00000` placeholder with the computed hash value.
+ */
+export function replaceCchPlaceholder(body: string, cch: string): string {
+  return body.replace(CCH_PLACEHOLDER, `cch=${cch}`);
+}
+
+/**
+ * Check if a body string contains the cch placeholder.
+ */
+export function hasCchPlaceholder(body: string): boolean {
+  return body.includes(CCH_PLACEHOLDER);
+}

--- a/src/services/oauth-client.ts
+++ b/src/services/oauth-client.ts
@@ -1,5 +1,6 @@
 import { getOAuthConfig } from '../config/oauth.js'
 import type { OAuthTokens } from '../types/oauth.js'
+import { computeCch, hasCchPlaceholder, replaceCchPlaceholder } from './cch.js'
 import { isOAuthTokenExpired, refreshOAuthToken } from './oauth-flow.js'
 import { loadStoredTokens, saveStoredTokens } from './token-store.js'
 
@@ -307,15 +308,29 @@ export async function callAnthropicApi(
 
 	try {
 		const apiBaseUrl = getOAuthConfig().baseApiUrl
-		const sendRequest = async (token: string): Promise<Response> =>
-			fetch(`${apiBaseUrl}${endpoint}`, {
+		const sendRequest = async (token: string): Promise<Response> => {
+			let body = JSON.stringify(payload)
+
+			// Compute and replace the cch placeholder with the xxHash64-based
+			// integrity hash, matching the signing that real Claude Code performs
+			// in Bun's native HTTP stack before sending the request.
+			if (
+				endpoint.includes('/v1/messages') &&
+				hasCchPlaceholder(body)
+			) {
+				const cch = await computeCch(body)
+				body = replaceCchPlaceholder(body, cch)
+			}
+
+			return fetch(`${apiBaseUrl}${endpoint}`, {
 				method: 'POST',
 				headers: {
 					...buildAnthropicHeaders(token, options),
 					'X-Stainless-Retry-Count': '0',
 				},
-				body: JSON.stringify(payload),
+				body,
 			})
+		}
 
 		let res = await sendRequest(resolvedAccessToken)
 

--- a/src/services/request-transformer.test.ts
+++ b/src/services/request-transformer.test.ts
@@ -194,7 +194,7 @@ describe('transformRequest', () => {
     expect((result.requestBody.tool_choice as { name: string }).name).toBe('get_user_data');
   });
 
-  it('should inject attribution header into system prompt without cch', async () => {
+  it('should inject attribution header with cch placeholder into system prompt', async () => {
     const body: MessageCreateParams = {
       model: 'claude-sonnet-4-5-20250929',
       max_tokens: 1024,
@@ -210,9 +210,9 @@ describe('transformRequest', () => {
     expect(system[0].text).toContain('x-anthropic-billing-header:');
     expect(system[0].text).toContain('cc_version=');
     expect(system[0].text).toContain('cc_entrypoint=cli');
-    // cch must NOT be present — the attestation hash cannot be forged
-    // from JS userland and including the placeholder is a tell
-    expect(system[0].text).not.toContain('cch=');
+    // cch=00000 placeholder should be present — it gets replaced with
+    // the computed xxHash64 integrity hash before the request is sent
+    expect(system[0].text).toContain('cch=00000');
   });
 
   it('should compute deterministic fingerprint from message content', () => {
@@ -228,12 +228,11 @@ describe('transformRequest', () => {
     expect(fp1).not.toBe(fp2);
   });
 
-  it('should build attribution header without cch field', () => {
+  it('should build attribution header with cch placeholder', () => {
     const header = getAttributionHeader('abc');
     expect(header).toBe(
-      'x-anthropic-billing-header: cc_version=2.1.87.abc; cc_entrypoint=cli;'
+      'x-anthropic-billing-header: cc_version=2.1.87.abc; cc_entrypoint=cli; cch=00000;'
     );
-    expect(header).not.toContain('cch=');
   });
 
   it('should vary attribution header fingerprint based on user message', async () => {

--- a/src/services/request-transformer.ts
+++ b/src/services/request-transformer.ts
@@ -242,21 +242,19 @@ export function computeFingerprint(messageText: string, version: string): string
  * into the first system prompt block.
  *
  * Format:
- *   x-anthropic-billing-header: cc_version=VERSION.FINGERPRINT; cc_entrypoint=cli;
+ *   x-anthropic-billing-header: cc_version=VERSION.FINGERPRINT; cc_entrypoint=cli; cch=00000;
  *
- * The real Claude Code binary conditionally includes a `cch=00000` placeholder
- * when the NATIVE_CLIENT_ATTESTATION compile-time feature flag is enabled.
- * Bun's native HTTP stack (Zig) then overwrites the zeros with a computed
- * attestation hash before the request leaves the process.
+ * Includes a `cch=00000` placeholder that is replaced with a computed
+ * xxHash64-based integrity hash before the request is sent. The route
+ * handler in messages.ts performs the replacement after serializing
+ * the full request body. The server verifies this token to gate
+ * features like fast mode.
  *
- * Since NATIVE_CLIENT_ATTESTATION is a compile-time flag only present in
- * the official Bun-bundled binary, and the attestation hash cannot be forged
- * from JS userland, we intentionally omit the cch field — matching the
- * behavior of non-official builds where the feature flag evaluates to false.
+ * See: https://a10k.co/b/reverse-engineering-claude-code-cch.html
  */
 export function getAttributionHeader(fingerprint: string): string {
   const version = `${EMULATED_CLI_VERSION}.${fingerprint}`;
-  return `x-anthropic-billing-header: cc_version=${version}; cc_entrypoint=cli;`;
+  return `x-anthropic-billing-header: cc_version=${version}; cc_entrypoint=cli; cch=00000;`;
 }
 
 function injectClaudeCodeSystemMessage(requestBody: MessageCreateParams): void {


### PR DESCRIPTION
## What

Implement the `cch` signing mechanism that the real Claude Code binary performs in Bun's native Zig HTTP stack. The `cch` field in the `x-anthropic-billing-header` is an xxHash64-based integrity hash over the serialized request body that gates features like **fast mode**.

## Background

The algorithm was [reverse-engineered](https://a10k.co/b/reverse-engineering-claude-code-cch.html) from the compiled Bun binary:

1. Build the complete request body with `cch=00000` as placeholder
2. Compute `xxHash64(body_bytes, seed=0x6E52736AC806831E) & 0xFFFFF`
3. Format as zero-padded 5-character lowercase hex
4. Replace `cch=00000` with the computed value in the body

In PR #3 we removed the `cch` placeholder because we couldn't forge the attestation hash from JS. Now we can — using `xxhash-wasm` (WebAssembly-based, fast and portable).

Based on: https://github.com/paoloanzn/free-code/pull/9

## Changes

- **`src/services/cch.ts`** — new module: `computeCch()`, `replaceCchPlaceholder()`, `hasCchPlaceholder()`
- **`src/services/oauth-client.ts`** — `callAnthropicApi()` now computes and replaces the cch hash before sending `/v1/messages` requests
- **`src/services/request-transformer.ts`** — restore `cch=00000` placeholder in attribution header
- **`xxhash-wasm`** dependency added
- Version bumped to **1.1.0**

## Tests

6 new cch-specific tests + updated existing tests = **124 pass, 0 fail**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `cch` request signing for Anthropic `/v1/messages`. We compute a 5‑char xxHash64 integrity token and replace the `cch=00000` placeholder before sending, matching Claude Code behavior and enabling fast mode compatibility.

- **New Features**
  - `getAttributionHeader` now includes `cch=00000`; `oauth-client` computes and injects the cch for `/v1/messages`.
  - Added `src/services/cch.ts` with `computeCch`, `replaceCchPlaceholder`, and `hasCchPlaceholder`.
  - 6 new tests; all tests passing.

- **Dependencies**
  - Added `xxhash-wasm` for WASM xxHash64 computation.
  - Version bumped to 1.1.0.

<sup>Written for commit 2e83b7607399454bec398d17e8fa3dd4fcf9c0aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

